### PR TITLE
examples/ci-tests make clean: remove some ignored files

### DIFF
--- a/examples/ci-tests/Makefile
+++ b/examples/ci-tests/Makefile
@@ -27,6 +27,7 @@ CFLAGS = -Wall -Werror -Wno-array-bounds
 clean:
 	@cargo clean
 	@rm -rf ${TMP}
+	@rm -rf c/test-vector-default.c c/test-vector-simple.c c/tests-api.h c/tests-gen.h
 
 tmpdir:
 	@if [ ! -d "${TARGET_TMP_DIR}" ]; then mkdir -p "${TARGET_TMP_DIR}"; fi


### PR DESCRIPTION
When the relevant code is updated, these files will not be regenerated, which may cause some problems.